### PR TITLE
fix engine setup and versioning

### DIFF
--- a/collection_north.gemspec
+++ b/collection_north.gemspec
@@ -9,15 +9,14 @@ Gem::Specification.new do |s|
   s.version     = CollectionNorth::VERSION
   s.authors     = ["criedlberger"]
   s.email       = ["riedlber@ualberta.ca"]
-  s.homepage    = "TODO"
-  s.summary     = "TODO: Summary of CollectionNorth."
-  s.description = "TODO: Description of CollectionNorth."
+  s.homepage    = "https://github.com/ualbertalib/CollectionNorth"
+  s.summary     = "Summary of CollectionNorth."
+  s.description = "Description of CollectionNorth."
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.2.5.2"
+  s.add_dependency "rails", "~> 4.2.0"
 
-  s.add_development_dependency "sqlite3"
 end

--- a/lib/collection_north.rb
+++ b/lib/collection_north.rb
@@ -1,4 +1,5 @@
-require "collection_north/engine"
+require 'collection_north/version'
+require 'collection_north/engine'
 
 module CollectionNorth
 end

--- a/lib/collection_north/engine.rb
+++ b/lib/collection_north/engine.rb
@@ -1,5 +1,8 @@
+require 'rails'
+
 module CollectionNorth
   class Engine < ::Rails::Engine
+    engine_name :collection_north
     isolate_namespace CollectionNorth
   end
 end


### PR DESCRIPTION
Tweaks some setup to ensure the engine loads successfully and is versoinable.

Also frees up the version restriction on Rails slightly, so it will float to the latest 4.2.x.